### PR TITLE
Added child logic to Stateless and Stateful widgets snippets

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -3,6 +3,8 @@
         "prefix": "stlss",
         "body": [
             "class ${1:name} extends StatelessWidget {",
+            "  final Widget ${2:child};\n",
+            "  ${1:name}({Key key, this.${2:child}}) : super(key: key);\n",
             "  @override",
             "  Widget build(BuildContext context) {",
             "    return Container(",
@@ -17,13 +19,15 @@
         "prefix": "stful",
         "body": [
             "class ${1:name} extends StatefulWidget {",
+            "  final Widget ${2:child};\n",
+            "  ${1:name}({Key key, this.${2:child}}) : super(key: key);\n",
             "  _${1:WidgetName}State createState() => _${1:WidgetName}State();",
             "}\n",
             "class _${1:index}State extends State<${1:index}> {",
             "  @override",
             "  Widget build(BuildContext context) {",
             "    return Container(",
-            "       child: ${2:child},",
+            "       child: widget.${2:child},",
             "    );",
             "  }",
             "}"


### PR DESCRIPTION
It would seem to me that having the child-related logic inside the snippet would be like 90% of use cases?
Or, add extra snippets for the child version. Otherwise, you often have a bunch of extra typing.