### PR TITLE
Add @override to Stateful Widget

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -19,6 +19,7 @@
         "body": [
             "class ${1:name} extends StatefulWidget {",
             "  ${1:name}({Key key}) : super(key: key);\n",
+	    "  @override",
             "  _${1:WidgetName}State createState() => _${1:WidgetName}State();",
             "}\n",
             "class _${1:index}State extends State<${1:index}> {",


### PR DESCRIPTION
to avoid `Annotate overridden members` dart analyzer warning.