### PR TITLE
Fix: spaces in StreamBuilder

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -173,9 +173,9 @@
         "prefix": "streamBldr",
         "body": [
             "StreamBuilder(",
-            "  stream: ${1:stream} ,",
-            "  initialData: ${2:initialData} ,",
-            "  builder: (BuildContext context, AsyncSnapshot snapshot){",
+            "  stream: ${1:stream},",
+            "  initialData: ${2:initialData},",
+            "  builder: (BuildContext context, AsyncSnapshot snapshot) {",
             "    return Container(",
             "      child: ${3:child},",
             "    );",


### PR DESCRIPTION
- Removed extra spaces after first and second args
- Added space before builder `{`