### PR TITLE
changed child container parameter to null

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -7,7 +7,7 @@
             "  @override",
             "  Widget build(BuildContext context) {",
             "    return Container(",
-            "      child: ${2:child},",
+            "      child: ${2:null},",
             "    );",
             "  }",
             "}"
@@ -26,7 +26,7 @@
             "  @override",
             "  Widget build(BuildContext context) {",
             "    return Container(",
-            "       child: ${2:child},",
+            "       child: ${2:null},",
             "    );",
             "  }",
             "}"


### PR DESCRIPTION
Changed `child` value parameter for containers of stateless and stateful widgets snippets to `null`. 

This change help for quickly tests or debugs. And remove lint error.

Thanks :)