### PR TITLE
[proposal] make widgets default to Container only

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -6,9 +6,7 @@
             "  const ${1:name}({Key? key}) : super(key: key);\n",
             "  @override",
             "  Widget build(BuildContext context) {",
-            "    return Container(",
-            "      child: ${2:null},",
-            "    );",
+            "    return Container();",
             "  }",
             "}"
         ],
@@ -25,9 +23,7 @@
             "class _${1:index}State extends State<${1:index}> {",
             "  @override",
             "  Widget build(BuildContext context) {",
-            "    return Container(",
-            "       child: ${2:null},",
-            "    );",
+            "    return Container();",
             "  }",
             "}"
         ],


### PR DESCRIPTION
Based on problems discussed in #36 it would be better if the widgets default to a simple Container. The point is to not have the error message because we didn't provided a widget.

Also closes #36.