### PR TITLE
refactor: use State<T> createState on statefulW snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -18,7 +18,7 @@
             "class ${1:name} extends StatefulWidget {",
             "  ${1:name}({Key? key}) : super(key: key);\n",
             "  @override",
-            "  _${1:WidgetName}State createState() => _${1:WidgetName}State();",
+            "  State<${1:index}> createState() => _${1:WidgetName}State();",
             "}\n",
             "class _${1:index}State extends State<${1:index}> {",
             "  @override",


### PR DESCRIPTION
Small refactor to StatefulWidget snippet to comply with the 'Avoid using private types in public APIs' lint. 

Issue: When using the private class name of the state, this lint is triggered. This refactor will avoid this warning when writing StatefulWidgets.

Example:

<img width="696" alt="Screen Shot 2021-11-22 at 11 00 42 PM" src="https://user-images.githubusercontent.com/31174242/142973582-bedabc67-dfa7-4ec7-a187-91cd6c922b18.png">

